### PR TITLE
Allow custom date formatting in generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,15 @@ You can clean out generated files with:
 make clean
 ```
 The clean target uses Python so it works on Windows as well as Unix-like systems.
+
+## Customizing date formats
+
+Templates can format dates using two global variables:
+
+- `run_date_format` controls how the `run_date` placeholder is rendered and
+  defaults to `%Y-%m-%d`.
+- `version_date_format` controls paths that incorporate the run date and
+  defaults to `%Y%m%d`.
+
+Override these values in your job-specific configuration files when a different
+format is required.

--- a/config-templates/audience/CalibrationInputDataGeneratorJob/behavioral_config.yml.j2
+++ b/config-templates/audience/CalibrationInputDataGeneratorJob/behavioral_config.yml.j2
@@ -5,7 +5,7 @@ experimentName: {{ experimentName }}
 model: "{{ model | default('RSMV2') }}"
 tag: "{{ tag | default('Seed_None') }}"
 version: {{ version | default(1) }}
-run_date: "{{ run_date }}" # job running logical date
+run_date: "{{ run_date.strftime(run_date_format) }}" # job running logical date
 lookBack: {{ lookBack | default(3) }}
 startDate: "{{ startDate | default('2025-02-13') }}"
 oosDataS3Bucket: "{{ oosDataS3Bucket | default('thetradedesk-mlplatform-us-east-1') }}"


### PR DESCRIPTION
## Summary
- allow formatting of the `run_date` placeholder
- keep placeholder quoting when dumping YAML
- let CalibrationInputDataGeneratorJob default to `%Y-%m-%d`
- document how to override date formats

## Testing
- `make build env=prod`


------
https://chatgpt.com/codex/tasks/task_e_68768ba78d5c8326822fee448e010aa9