### PR TITLE
Add RelevanceModelOfflineScoringPart2 job

### DIFF
--- a/config-templates/audience/RelevanceModelOfflineScoringPart2/behavioral_config.yml.j2
+++ b/config-templates/audience/RelevanceModelOfflineScoringPart2/behavioral_config.yml.j2
@@ -1,0 +1,42 @@
+environment: {{ environment }}
+{% if experimentName is defined %}
+experimentName: {{ experimentName }}
+{% endif %}
+salt: "{{ salt | default('TRM') }}"
+br_emb_path: "{{ br_emb_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/RSMV2/emb/raw/v=1/date=' ~ run_date.strftime(version_date_format) ~ '/') }}"
+tdid_emb_path: "{{ tdid_emb_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/RSMV2/emb/agg/v=1/date=' ~ run_date.strftime(version_date_format) ~ '/') }}"
+decode_tdid: {{ decode_tdid | default(true) | lower }}
+emb_bucket_dest: "{{ emb_bucket_dest | default('s3://ttd-user-embeddings/dataexport/' if environment == 'prod' else 's3://thetradedesk-mlplatform-us-east-1/data/prodTest/audience/emb/dataexport/') }}"
+nonsensitive_emb_enum: {{ nonsensitive_emb_enum | default(301) }}
+sensitive_emb_enum: {{ sensitive_emb_enum | default(302) }}
+base_hour: {{ base_hour | default(0) }}
+batch_id: {{ batch_id | default(1) }}
+seed_emb_path: "{{ seed_emb_path | default('s3://thetradedesk-mlplatform-us-east-1/configdata/test/audience/embedding/RSMV2/RSMv2SensitiveDensityTest/v=1/' ~ run_date.strftime(version_date_format) ~ '000000/') }}"
+density_feature_path: "{{ density_feature_path | default('s3://thetradedesk-mlplatform-us-east-1/features/feature_store/prod/profiles/source=bidsimpression/index=TDID/job=DailyTDIDDensityScoreSplitJob/v=1/date=' ~ run_date.strftime(version_date_format) ~ '/') }}"
+policy_table_path: "{{ policy_table_path | default('s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/' ~ run_date.strftime(version_date_format) ~ '000000/') }}"
+seed_id_path: "{{ seed_id_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/seedids/v=2/date=' ~ run_date.strftime(version_date_format) ~ '/') }}"
+dot_product_out_path: "{{ dot_product_out_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/tdid2seedid_raw/v=1/date=' ~ run_date.strftime(version_date_format) ~ '/') }}"
+density_split: {{ density_split | default(-1) }}
+density_limit: {{ density_limit | default(-1) }}
+tdid_limit: {{ tdid_limit | default(-1) }}
+debug: {{ debug | default(false) | lower }}
+partition: {{ partition | default(-1) }}
+sensitiveModel: {{ sensitiveModel | default(true) | lower }}
+minMaxSeedEmb: {{ minMaxSeedEmb | default(1e-6) }}
+r: {{ r | default(1e-8) }}
+loc_factor: {{ loc_factor | default(0.8) }}
+raw_score_path: "{{ raw_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/tdid2seedid_raw/v=1/date=' ~ run_date.strftime(version_date_format) ~ '/') }}"
+score_scale_out_path: "{{ score_scale_out_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/tdid2seedid/v=1/date=' ~ run_date.strftime(version_date_format) ~ '/') }}"
+population_score_path: "{{ population_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/seedpopulationscore/v=1/date=' ~ run_date.strftime(version_date_format) ~ '/') }}"
+smooth_factor: {{ smooth_factor | default(30.0) }}
+userLevelUpperCap: {{ userLevelUpperCap | default(1000000.0) }}
+accuracy: {{ accuracy | default(1000) }}
+sampleRateForPercentile: {{ sampleRateForPercentile | default(0.3) }}
+skipPercentile: {{ skipPercentile | default(true) | lower }}
+daysLookback: {{ daysLookback | default(1) }}
+percentileDiffThreshold: {{ percentileDiffThreshold | default(0.002) }}
+seedOutlinerPercentThreshold: {{ seedOutlinerPercentThreshold | default(0.05) }}
+runDate: "{{ run_date.strftime(run_date_format) }}"
+
+audienceJarBranch: "{{ audienceJarBranch | default('master') }}"
+audienceJarVersion: "{{ audienceJarVersion | default('latest') }}"

--- a/config-templates/audience/RelevanceModelOfflineScoringPart2/output_config.yml.j2
+++ b/config-templates/audience/RelevanceModelOfflineScoringPart2/output_config.yml.j2
@@ -1,0 +1,5 @@
+seed_id_path: "{{ seed_id_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/seedids/v=2/date=' ~ run_date.strftime(version_date_format) ~ '/') }}"
+dot_product_out_path: "{{ dot_product_out_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/tdid2seedid_raw/v=1/date=' ~ run_date.strftime(version_date_format) ~ '/') }}"
+score_scale_out_path: "{{ score_scale_out_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/tdid2seedid/v=1/date=' ~ run_date.strftime(version_date_format) ~ '/') }}"
+population_score_path: "{{ population_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/seedpopulationscore/v=1/date=' ~ run_date.strftime(version_date_format) ~ '/') }}"
+tdid_emb_path: "{{ tdid_emb_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/RSMV2/emb/agg/v=1/date=' ~ run_date.strftime(version_date_format) ~ '/') }}"

--- a/configs/experiment/yanan-demo/audience/RelevanceModelOfflineScoringPart2/behavioral_config.yml
+++ b/configs/experiment/yanan-demo/audience/RelevanceModelOfflineScoringPart2/behavioral_config.yml
@@ -1,0 +1,39 @@
+environment: experiment
+experimentName: yanan-demo
+salt: TRM
+br_emb_path: "s3://thetradedesk-mlplatform-us-east-1/data/experiment/yanan-demo/audience/RSMV2/emb/raw/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+tdid_emb_path: "s3://thetradedesk-mlplatform-us-east-1/data/experiment/yanan-demo/audience/RSMV2/emb/agg/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+decode_tdid: true
+emb_bucket_dest: s3://thetradedesk-mlplatform-us-east-1/data/prodTest/audience/emb/dataexport/
+nonsensitive_emb_enum: 301
+sensitive_emb_enum: 302
+base_hour: 0
+batch_id: 1
+seed_emb_path: "s3://thetradedesk-mlplatform-us-east-1/configdata/test/audience/embedding/RSMV2/RSMv2SensitiveDensityTest/v=1/{{ run_date.strftime('%Y%m%d') }}000000/"
+density_feature_path: "s3://thetradedesk-mlplatform-us-east-1/features/feature_store/prod/profiles/source=bidsimpression/index=TDID/job=DailyTDIDDensityScoreSplitJob/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+policy_table_path: "s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/{{ run_date.strftime('%Y%m%d') }}000000/"
+seed_id_path: "s3://thetradedesk-mlplatform-us-east-1/data/experiment/yanan-demo/audience/scores/seedids/v=2/date={{ run_date.strftime('%Y%m%d') }}/"
+dot_product_out_path: "s3://thetradedesk-mlplatform-us-east-1/data/experiment/yanan-demo/audience/scores/tdid2seedid_raw/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+density_split: -1
+density_limit: -1
+tdid_limit: -1
+debug: false
+partition: -1
+sensitiveModel: true
+minMaxSeedEmb: 1e-06
+r: 1e-08
+loc_factor: 0.8
+raw_score_path: "s3://thetradedesk-mlplatform-us-east-1/data/experiment/yanan-demo/audience/scores/tdid2seedid_raw/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+score_scale_out_path: "s3://thetradedesk-mlplatform-us-east-1/data/experiment/yanan-demo/audience/scores/tdid2seedid/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+population_score_path: "s3://thetradedesk-mlplatform-us-east-1/data/experiment/yanan-demo/audience/scores/seedpopulationscore/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+smooth_factor: 30.0
+userLevelUpperCap: 1000000.0
+accuracy: 1000
+sampleRateForPercentile: 0.3
+skipPercentile: true
+daysLookback: 1
+percentileDiffThreshold: 0.002
+seedOutlinerPercentThreshold: 0.05
+runDate: "{{ run_date.strftime('%Y-%m-%d') }}"
+audienceJarBranch: master
+audienceJarVersion: latest

--- a/configs/experiment/yanan-demo/audience/RelevanceModelOfflineScoringPart2/output_config.yml
+++ b/configs/experiment/yanan-demo/audience/RelevanceModelOfflineScoringPart2/output_config.yml
@@ -1,0 +1,5 @@
+seed_id_path: "s3://thetradedesk-mlplatform-us-east-1/data/experiment/yanan-demo/audience/scores/seedids/v=2/date={{ run_date.strftime('%Y%m%d') }}/"
+dot_product_out_path: "s3://thetradedesk-mlplatform-us-east-1/data/experiment/yanan-demo/audience/scores/tdid2seedid_raw/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+score_scale_out_path: "s3://thetradedesk-mlplatform-us-east-1/data/experiment/yanan-demo/audience/scores/tdid2seedid/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+population_score_path: "s3://thetradedesk-mlplatform-us-east-1/data/experiment/yanan-demo/audience/scores/seedpopulationscore/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+tdid_emb_path: "s3://thetradedesk-mlplatform-us-east-1/data/experiment/yanan-demo/audience/RSMV2/emb/agg/v=1/date={{ run_date.strftime('%Y%m%d') }}/"

--- a/configs/prod/audience/RelevanceModelOfflineScoringPart2/behavioral_config.yml
+++ b/configs/prod/audience/RelevanceModelOfflineScoringPart2/behavioral_config.yml
@@ -1,0 +1,38 @@
+environment: prod
+salt: TRM
+br_emb_path: "s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/RSMV2/emb/raw/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+tdid_emb_path: "s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/RSMV2/emb/agg/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+decode_tdid: true
+emb_bucket_dest: s3://ttd-user-embeddings/dataexport/
+nonsensitive_emb_enum: 301
+sensitive_emb_enum: 302
+base_hour: 0
+batch_id: 1
+seed_emb_path: "s3://thetradedesk-mlplatform-us-east-1/configdata/test/audience/embedding/RSMV2/RSMv2SensitiveDensityTest/v=1/{{ run_date.strftime('%Y%m%d') }}000000/"
+density_feature_path: "s3://thetradedesk-mlplatform-us-east-1/features/feature_store/prod/profiles/source=bidsimpression/index=TDID/job=DailyTDIDDensityScoreSplitJob/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+policy_table_path: "s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/{{ run_date.strftime('%Y%m%d') }}000000/"
+seed_id_path: "s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/scores/seedids/v=2/date={{ run_date.strftime('%Y%m%d') }}/"
+dot_product_out_path: "s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/scores/tdid2seedid_raw/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+density_split: -1
+density_limit: -1
+tdid_limit: -1
+debug: false
+partition: -1
+sensitiveModel: true
+minMaxSeedEmb: 1e-06
+r: 1e-08
+loc_factor: 0.8
+raw_score_path: "s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/scores/tdid2seedid_raw/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+score_scale_out_path: "s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/scores/tdid2seedid/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+population_score_path: "s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/scores/seedpopulationscore/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+smooth_factor: 30.0
+userLevelUpperCap: 1000000.0
+accuracy: 1000
+sampleRateForPercentile: 0.3
+skipPercentile: true
+daysLookback: 1
+percentileDiffThreshold: 0.002
+seedOutlinerPercentThreshold: 0.05
+runDate: "{{ run_date.strftime('%Y-%m-%d') }}"
+audienceJarBranch: master
+audienceJarVersion: latest

--- a/configs/prod/audience/RelevanceModelOfflineScoringPart2/output_config.yml
+++ b/configs/prod/audience/RelevanceModelOfflineScoringPart2/output_config.yml
@@ -1,0 +1,5 @@
+seed_id_path: "s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/scores/seedids/v=2/date={{ run_date.strftime('%Y%m%d') }}/"
+dot_product_out_path: "s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/scores/tdid2seedid_raw/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+score_scale_out_path: "s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/scores/tdid2seedid/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+population_score_path: "s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/scores/seedpopulationscore/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+tdid_emb_path: "s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/RSMV2/emb/agg/v=1/date={{ run_date.strftime('%Y%m%d') }}/"

--- a/configs/test/yanan-demo/audience/RelevanceModelOfflineScoringPart2/behavioral_config.yml
+++ b/configs/test/yanan-demo/audience/RelevanceModelOfflineScoringPart2/behavioral_config.yml
@@ -1,0 +1,39 @@
+environment: test
+experimentName: yanan-demo
+salt: TRM
+br_emb_path: "s3://thetradedesk-mlplatform-us-east-1/data/test/yanan-demo/audience/RSMV2/emb/raw/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+tdid_emb_path: "s3://thetradedesk-mlplatform-us-east-1/data/test/yanan-demo/audience/RSMV2/emb/agg/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+decode_tdid: true
+emb_bucket_dest: s3://thetradedesk-mlplatform-us-east-1/data/prodTest/audience/emb/dataexport/
+nonsensitive_emb_enum: 301
+sensitive_emb_enum: 302
+base_hour: 0
+batch_id: 1
+seed_emb_path: "s3://thetradedesk-mlplatform-us-east-1/configdata/test/audience/embedding/RSMV2/RSMv2SensitiveDensityTest/v=1/{{ run_date.strftime('%Y%m%d') }}000000/"
+density_feature_path: "s3://thetradedesk-mlplatform-us-east-1/features/feature_store/prod/profiles/source=bidsimpression/index=TDID/job=DailyTDIDDensityScoreSplitJob/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+policy_table_path: "s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/{{ run_date.strftime('%Y%m%d') }}000000/"
+seed_id_path: "s3://thetradedesk-mlplatform-us-east-1/data/test/yanan-demo/audience/scores/seedids/v=2/date={{ run_date.strftime('%Y%m%d') }}/"
+dot_product_out_path: "s3://thetradedesk-mlplatform-us-east-1/data/test/yanan-demo/audience/scores/tdid2seedid_raw/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+density_split: -1
+density_limit: -1
+tdid_limit: -1
+debug: false
+partition: -1
+sensitiveModel: true
+minMaxSeedEmb: 1e-06
+r: 1e-08
+loc_factor: 0.8
+raw_score_path: "s3://thetradedesk-mlplatform-us-east-1/data/test/yanan-demo/audience/scores/tdid2seedid_raw/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+score_scale_out_path: "s3://thetradedesk-mlplatform-us-east-1/data/test/yanan-demo/audience/scores/tdid2seedid/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+population_score_path: "s3://thetradedesk-mlplatform-us-east-1/data/test/yanan-demo/audience/scores/seedpopulationscore/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+smooth_factor: 30.0
+userLevelUpperCap: 1000000.0
+accuracy: 1000
+sampleRateForPercentile: 0.3
+skipPercentile: true
+daysLookback: 1
+percentileDiffThreshold: 0.002
+seedOutlinerPercentThreshold: 0.05
+runDate: "{{ run_date.strftime('%Y-%m-%d') }}"
+audienceJarBranch: master
+audienceJarVersion: latest

--- a/configs/test/yanan-demo/audience/RelevanceModelOfflineScoringPart2/output_config.yml
+++ b/configs/test/yanan-demo/audience/RelevanceModelOfflineScoringPart2/output_config.yml
@@ -1,0 +1,5 @@
+seed_id_path: "s3://thetradedesk-mlplatform-us-east-1/data/test/yanan-demo/audience/scores/seedids/v=2/date={{ run_date.strftime('%Y%m%d') }}/"
+dot_product_out_path: "s3://thetradedesk-mlplatform-us-east-1/data/test/yanan-demo/audience/scores/tdid2seedid_raw/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+score_scale_out_path: "s3://thetradedesk-mlplatform-us-east-1/data/test/yanan-demo/audience/scores/tdid2seedid/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+population_score_path: "s3://thetradedesk-mlplatform-us-east-1/data/test/yanan-demo/audience/scores/seedpopulationscore/v=1/date={{ run_date.strftime('%Y%m%d') }}/"
+tdid_emb_path: "s3://thetradedesk-mlplatform-us-east-1/data/test/yanan-demo/audience/RSMV2/emb/agg/v=1/date={{ run_date.strftime('%Y%m%d') }}/"


### PR DESCRIPTION
## Summary
- add templates for new `RelevanceModelOfflineScoringPart2` job
- include generated configs for all environments

## Testing
- `make build env=all`

------
https://chatgpt.com/codex/tasks/task_e_687e55870e20832683bc649c3f0619c3