### PR TITLE
Update GitLab CI for environment-specific sync rules

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,14 +1,44 @@
 stages:
   - deploy
 
-deploy_configs:
+.deploy_template:
   image: python:3.9
   stage: deploy
   before_script:
     - pip install --quiet awscli
+
+deploy_test_configs:
+  extends: .deploy_template
   script:
-    - aws s3 sync configs s3://thetradedesk-mlplatform-us-east-1/configdata/confetti/
+    - aws s3 sync configs/test s3://thetradedesk-mlplatform-us-east-1/configdata/confetti/test/
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      changes:
+        - configs/test/**/*
+        - config-overrides/test/**/*
+      when: on_success
+    - when: never
+
+deploy_prod_configs:
+  extends: .deploy_template
+  script:
+    - aws s3 sync configs/prod s3://thetradedesk-mlplatform-us-east-1/configdata/confetti/prod/
   rules:
     - if: '$CI_COMMIT_BRANCH == "master"'
+      changes:
+        - configs/prod/**/*
+        - config-overrides/prod/**/*
+      when: on_success
+    - when: never
+
+deploy_experiment_configs:
+  extends: .deploy_template
+  script:
+    - aws s3 sync configs/experiment s3://thetradedesk-mlplatform-us-east-1/configdata/confetti/experiment/
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master"'
+      changes:
+        - configs/experiment/**/*
+        - config-overrides/experiment/**/*
       when: on_success
     - when: never


### PR DESCRIPTION
## Summary
- customize CI pipeline for environment-specific S3 sync
- deploy test configs when merge requests are opened
- require master branch for prod and experiment configs

## Testing
- `make build env=prod`

------
https://chatgpt.com/codex/tasks/task_e_687f175359088326bc756117569948cc