### PR TITLE
Enable automatic config generation in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,5 @@
 stages:
+  - generate
   - deploy
 
 .deploy_template:
@@ -6,6 +7,27 @@ stages:
   stage: deploy
   before_script:
     - pip install --quiet awscli
+
+auto_generate_configs:
+  image: python:3.9
+  stage: generate
+  before_script:
+    - apt-get update -y && apt-get install -y make git
+  script:
+    - make build env=all
+    - |
+      if ! git diff --quiet; then
+        git config user.email "${GITLAB_USER_EMAIL:-ci@example.com}"
+        git config user.name "${GITLAB_USER_NAME:-CI}"
+        git add configs
+        git commit -m "ci: auto-generate configs"
+        git push https://gitlab-ci-token:${CI_JOB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git HEAD:${CI_COMMIT_BRANCH}
+      fi
+  rules:
+    - changes:
+        - config-overrides/**/*
+      when: on_success
+    - when: never
 
 deploy_test_configs:
   extends: .deploy_template

--- a/README.md
+++ b/README.md
@@ -73,3 +73,10 @@ Templates can format dates using two global variables:
 
 Override these values in your job-specific configuration files when a different
 format is required.
+
+## CI pipeline
+
+When a merge request updates `config-overrides/` without regenerating the files
+under `configs/`, the GitLab pipeline automatically runs `make build env=all`.
+If new files are produced, a commit named `ci: auto-generate configs` is pushed
+back to the branch so the generated configs stay in sync.


### PR DESCRIPTION
## Summary
- add a CI job that runs `make build env=all` and pushes new configs back to the MR branch
- document CI behaviour in README

## Testing
- `python -m py_compile generate_configs.py`

------
https://chatgpt.com/codex/tasks/task_e_687f254b6ad083268f611c02f240a3aa