### PR TITLE
Stop pipeline after auto config generation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,8 @@ auto_generate_configs:
         git add configs
         git commit -m "ci: auto-generate configs"
         git push https://gitlab-ci-token:${CI_JOB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git HEAD:${CI_COMMIT_BRANCH}
+        echo "Generated configs updated, stopping pipeline"
+        exit 1
       fi
   rules:
     - changes:

--- a/README.md
+++ b/README.md
@@ -81,4 +81,5 @@ format is required.
 When a merge request updates `config-overrides/` without regenerating the files
 under `configs/`, the GitLab pipeline automatically runs `make build env=all`.
 If new files are produced, a commit named `ci: auto-generate configs` is pushed
-back to the branch so the generated configs stay in sync.
+back to the branch so the generated configs stay in sync. The generate job then
+fails to stop the current pipeline so the next run performs the deployment.


### PR DESCRIPTION
## Summary
- update auto_generate_configs job to exit when it pushes new configs
- document pipeline behavior in README

## Testing
- `make build env=all`

------
https://chatgpt.com/codex/tasks/task_e_6880a476602483269ef97aee0d1974da