### PR TITLE
Fix auto config generation push

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ auto_generate_configs:
         git config user.name "${GITLAB_USER_NAME:-CI}"
         git add configs
         git commit -m "ci: auto-generate configs"
-        git push https://gitlab-ci-token:${CI_JOB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git HEAD:${CI_COMMIT_BRANCH}
+        git push https://gitlab-ci-token:${CI_JOB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git HEAD:${CI_COMMIT_REF_NAME}
         echo "Generated configs updated, stopping pipeline"
         exit 1
       fi


### PR DESCRIPTION
## Summary
- fix push branch to use `CI_COMMIT_REF_NAME`

## Testing
- `make build env=all`

------
https://chatgpt.com/codex/tasks/task_e_6886ef620dc48326a713f9791d1c74e5