### PR TITLE
Warn when override configs are absent and generate defaults

### DIFF
--- a/config-overrides/prod/audience/CalibrationInputDataGeneratorJob/config.yml
+++ b/config-overrides/prod/audience/CalibrationInputDataGeneratorJob/config.yml
@@ -1,2 +1,0 @@
-# Default config for CalibrationInputDataGeneratorJob in experiment
-#lookBack: 11


### PR DESCRIPTION
## Summary
- ensure every group under config-overrides is generated even without override files
- log a warning when a job lacks an override config but continue using defaults
- drop placeholder prod override and keep empty dir

## Testing
- `make build env=prod`


------
https://chatgpt.com/codex/tasks/task_e_68919977ddc0832687284886208f27c9