### PR TITLE
Add runtime config generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ __pycache__/
 dist/
 build/
 coverage/
-.vscode/ 
+.vscode/
+runtime-configs/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 env ?=
 exp ?=
+job ?=
+run_date ?=
 
-.PHONY: build clean
+.PHONY: build clean generate-runtime-config
 
 ARGS := env=$(env)
 ifneq ($(strip $(exp)),)
@@ -12,3 +14,17 @@ build:
 	python3 generate_configs.py $(ARGS)
 clean:
 	python -c "import shutil, os; shutil.rmtree('configs', ignore_errors=True); os.makedirs('configs', exist_ok=True)"
+
+RUNTIME_ARGS := env=$(env)
+ifneq ($(strip $(exp)),)
+RUNTIME_ARGS += exp=$(exp)
+endif
+ifneq ($(strip $(job)),)
+RUNTIME_ARGS += job=$(job)
+endif
+ifneq ($(strip $(run_date)),)
+RUNTIME_ARGS += run_date=$(run_date)
+endif
+
+generate-runtime-config:
+	python3 generate_runtime_config.py $(RUNTIME_ARGS)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ make clean
 ```
 The clean target uses Python so it works on Windows as well as Unix-like systems.
 
+### Runtime configuration
+
+Once build-time configs are generated, runtime values such as `run_date` can be
+resolved and uploaded to a hashed location. Use:
+
+```bash
+make generate-runtime-config env=<env> [exp=<exp>] [job=<job>] run_date=<YYYYMMDD>
+```
+
+Non-production environments require an `exp` value while production must omit it.
+The command renders the runtime configuration, injects the `audienceJarPath`,
+writes the files under `runtime-configs/` and uploads them to the matching S3
+location.
+
 ## Reserved keywords
 
 The generator populates several keys automatically, which helps user to populate values automatically, or as 

--- a/generate_runtime_config.py
+++ b/generate_runtime_config.py
@@ -1,0 +1,207 @@
+import os
+import sys
+import subprocess
+import importlib
+import base64
+import hashlib
+import datetime
+from typing import Dict, Optional
+
+
+def log_info(message: str) -> None:
+    """Log an informational message."""
+    print(f"[INFO] {message}")
+
+
+# Ensure the script is executed with Python 3
+if sys.version_info.major < 3:
+    print("This script requires Python 3.", file=sys.stderr)
+    sys.exit(1)
+
+
+def ensure_dependency(pkg: str, import_name: Optional[str] = None) -> None:
+    """Install the given package if the import fails."""
+    import_name = import_name or pkg
+    try:
+        importlib.import_module(import_name)
+    except ImportError:
+        log_info(f"Installing missing dependency {pkg}...")
+        subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])
+
+
+ensure_dependency("PyYAML", "yaml")
+ensure_dependency("Jinja2", "jinja2")
+ensure_dependency("boto3")
+
+import yaml
+from jinja2 import Environment, BaseLoader, StrictUndefined
+import boto3
+
+
+class AwsCloudStorage:
+    """Minimal wrapper around S3 operations."""
+
+    def __init__(self) -> None:
+        self.s3 = boto3.client("s3")
+
+    @staticmethod
+    def _parse_uri(uri: str):
+        if not uri.startswith("s3://"):
+            raise ValueError(f"Invalid S3 URI: {uri}")
+        bucket, _, key = uri[5:].partition("/")
+        return bucket, key
+
+    def read_key(self, uri: str) -> str:
+        bucket, key = self._parse_uri(uri)
+        obj = self.s3.get_object(Bucket=bucket, Key=key)
+        return obj["Body"].read().decode("utf-8")
+
+    def upload_string(self, uri: str, data: str) -> None:
+        bucket, key = self._parse_uri(uri)
+        self.s3.put_object(Bucket=bucket, Key=key, Body=data.encode("utf-8"))
+
+
+def _inject_audience_jar_path(rendered: str, aws: AwsCloudStorage) -> str:
+    """Compute audienceJarPath from branch and version and remove those keys."""
+    try:
+        data = yaml.safe_load(rendered)
+    except Exception as exc:  # pragma: no cover - malformed YAML
+        raise ValueError(f"Failed to parse Confetti YAML: {exc}") from exc
+
+    if not isinstance(data, dict):  # pragma: no cover - unexpected structure
+        raise ValueError("Confetti YAML must be a mapping")
+
+    if "audienceJarBranch" not in data:
+        raise ValueError("audienceJarBranch is required in Confetti config")
+    if "audienceJarVersion" not in data:
+        raise ValueError("audienceJarVersion is required in Confetti config")
+
+    branch = str(data.pop("audienceJarBranch"))
+    version = str(data.pop("audienceJarVersion"))
+
+    version_value = version
+    if version.lower() == "latest":
+        if branch == "master":
+            current_key = (
+                "s3://thetradedesk-mlplatform-us-east-1/libs/audience/jars/prod/_CURRENT"
+            )
+        else:
+            current_key = (
+                f"s3://thetradedesk-mlplatform-us-east-1/libs/audience/jars/mergerequests/{branch}/_CURRENT"
+            )
+        lines = aws.read_key(current_key).splitlines()
+        if not lines or not lines[0].strip():
+            raise ValueError(f"No version found in {current_key}")
+        version_value = lines[0].strip()
+
+    if branch == "master":
+        jar_path = (
+            "s3://thetradedesk-mlplatform-us-east-1/libs/audience/jars/snapshots/master/"
+            f"{version_value}/audience.jar"
+        )
+    else:
+        jar_path = (
+            "s3://thetradedesk-mlplatform-us-east-1/libs/audience/jars/mergerequests/"
+            f"{branch}/{version_value}/audience.jar"
+        )
+
+    data["audienceJarPath"] = jar_path
+    return yaml.safe_dump(data, sort_keys=True)
+
+
+def _sha256_b64(data: str) -> str:
+    return base64.urlsafe_b64encode(hashlib.sha256(data.encode("utf-8")).digest()).decode()
+
+
+CONFIG_ROOT = "configs"
+RUNTIME_ROOT = "runtime-configs"
+
+
+def parse_cli_args(argv):
+    params: Dict[str, str] = {}
+    for arg in argv:
+        if "=" in arg:
+            k, v = arg.split("=", 1)
+            params[k] = v
+    env = params.get("env")
+    if not env:
+        print("env parameter is required", file=sys.stderr)
+        sys.exit(1)
+    exp = params.get("exp")
+    job = params.get("job")
+
+    # Validate env/exp relationship
+    if env == "prod":
+        if exp is not None:
+            print("exp parameter must not be provided when env=prod", file=sys.stderr)
+            sys.exit(1)
+    else:
+        if not exp:
+            print("exp parameter is required for non-prod environments", file=sys.stderr)
+            sys.exit(1)
+
+    runtime_args = {k: yaml.safe_load(v) for k, v in params.items() if k not in {"env", "exp", "job"}}
+    if "run_date" in runtime_args:
+        run_date_raw = str(runtime_args["run_date"])
+        runtime_args["run_date"] = datetime.datetime.strptime(run_date_raw, "%Y%m%d").date()
+
+    return env, exp, job, runtime_args
+
+
+def render_job(env_path: str, job: str, runtime_args: Dict[str, object], aws: AwsCloudStorage) -> None:
+    job_dir = os.path.join(CONFIG_ROOT, env_path, "audience", job)
+    if not os.path.isdir(job_dir):
+        raise ValueError(f"Job directory not found: {job_dir}")
+
+    jenv = Environment(loader=BaseLoader, undefined=StrictUndefined)
+
+    rendered_files: Dict[str, str] = {}
+    for filename in os.listdir(job_dir):
+        if not filename.endswith(".yml"):
+            continue
+        path = os.path.join(job_dir, filename)
+        with open(path) as f:
+            template = jenv.from_string(f.read())
+        rendered = template.render(**runtime_args)
+        if filename == "identity_config.yml":
+            rendered = _inject_audience_jar_path(rendered, aws)
+        rendered_files[filename] = rendered
+
+    if "identity_config.yml" not in rendered_files:
+        raise ValueError("identity_config.yml is required for hashing")
+
+    hash_input = "".join(rendered_files[f] for f in sorted(rendered_files))
+    hash_id = _sha256_b64(hash_input)
+
+    out_dir = os.path.join(RUNTIME_ROOT, env_path, "audience", job, hash_id)
+    os.makedirs(out_dir, exist_ok=True)
+
+    s3_prefix = (
+        "s3://thetradedesk-mlplatform-us-east-1/configdata/confetti/"
+        f"{RUNTIME_ROOT}/{env_path}/audience/{job}/{hash_id}/"
+    )
+
+    for filename, content in rendered_files.items():
+        out_path = os.path.join(out_dir, filename)
+        with open(out_path, "w") as f:
+            f.write(content)
+        aws.upload_string(s3_prefix + filename, content)
+    log_info(f"Generated runtime configs for {env_path}/{job} -> {hash_id}")
+
+
+def main(argv):
+    env, exp, job, runtime_args = parse_cli_args(argv)
+    env_path = f"{env}/{exp}" if exp else env
+    aws = AwsCloudStorage()
+
+    base_dir = os.path.join(CONFIG_ROOT, env_path, "audience")
+    if not os.path.isdir(base_dir):
+        raise ValueError(f"No configs found under {base_dir}")
+
+    jobs = [job] if job else [d for d in os.listdir(base_dir) if os.path.isdir(os.path.join(base_dir, d))]
+    for j in jobs:
+        render_job(env_path, j, runtime_args, aws)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- add CLI to render runtime configs, inject audience jar path and upload to hashed S3 locations
- document and expose make target for runtime config generation

## Testing
- `python -m py_compile generate_runtime_config.py`
- `make generate-runtime-config env=prod run_date=20250808 job=RelevanceModelOfflineScoringPart2` *(fails: NoCredentialsError: Unable to locate credentials)*

------
https://chatgpt.com/codex/tasks/task_e_689b1b1a92ec8326b2c2ff28fe3b7132