### PR TITLE
Refactor runtime config generation for group-aware CLI and resilient uploads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 env ?=
 exp ?=
+group ?=
 job ?=
 run_date ?=
 
@@ -18,6 +19,9 @@ clean:
 RUNTIME_ARGS := env=$(env)
 ifneq ($(strip $(exp)),)
 RUNTIME_ARGS += exp=$(exp)
+endif
+ifneq ($(strip $(group)),)
+RUNTIME_ARGS += group=$(group)
 endif
 ifneq ($(strip $(job)),)
 RUNTIME_ARGS += job=$(job)

--- a/README.md
+++ b/README.md
@@ -82,13 +82,14 @@ Once build-time configs are generated, runtime values such as `run_date` can be
 resolved and uploaded to a hashed location. Use:
 
 ```bash
-make generate-runtime-config env=<env> [exp=<exp>] [job=<job>] run_date=<YYYYMMDD>
+make generate-runtime-config env=<env> [exp=<exp>] [group=<group>] [job=<job>] run_date=<YYYYMMDD>
 ```
 
-Non-production environments require an `exp` value while production must omit it.
-The command renders the runtime configuration, injects the `audienceJarPath`,
-writes the files under `runtime-configs/` and uploads them to the matching S3
-location.
+`group` specifies the job group name (for example, `audience`) and defaults to
+`audience` when omitted. Non-production environments require an `exp` value while
+production must omit it. The command renders the runtime configuration, injects
+the `audienceJarPath`, writes the files under `runtime-configs/` and uploads them
+to the matching S3 location.
 
 ## Reserved keywords
 


### PR DESCRIPTION
## Summary
- allow runtime generator to take a `group` CLI argument and use it for config paths
- write runtime configs locally before attempting S3 uploads and surface any upload failures
- document and wire `group` through Makefile

## Testing
- `python -m py_compile generate_runtime_config.py`


------
https://chatgpt.com/codex/tasks/task_e_689b3a4bc53083268d1a49a5875cc71e