### PR TITLE
Add prototype service for one-click EMR job launcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 env ?=
 exp ?=
 
-.PHONY: build clean
+.PHONY: build clean serve
 
 ARGS := env=$(env)
 ifneq ($(strip $(exp)),)
@@ -9,6 +9,9 @@ ARGS += exp=$(exp)
 endif
 
 build:
-	python3 generate_configs.py $(ARGS)
+        python3 generate_configs.py $(ARGS)
 clean:
-	python -c "import shutil, os; shutil.rmtree('configs', ignore_errors=True); os.makedirs('configs', exist_ok=True)"
+        python -c "import shutil, os; shutil.rmtree('configs', ignore_errors=True); os.makedirs('configs', exist_ok=True)"
+
+serve:
+        python3 -m emr_launcher.service

--- a/README.md
+++ b/README.md
@@ -76,6 +76,27 @@ make clean
 ```
 The clean target uses Python so it works on Windows as well as Unix-like systems.
 
+## EMR launcher service
+
+This repository also contains a very small Flask application that acts as a
+prototype for the proposed “one click” EMR job launcher. The service exposes
+two endpoints:
+
+* `POST /jobs` – render configs and submit a new cluster based on a job
+  template.
+* `POST /clone` – clone an existing cluster with optional configuration
+  overrides.
+
+Start the service locally with:
+
+```bash
+make serve
+```
+
+The implementation is intentionally lightweight and omits most error handling
+and user interface pieces. It is meant to serve as a starting point for
+further development.
+
 ## Reserved keywords
 
 The generator populates several keys automatically, which helps user to populate values automatically, or as 

--- a/emr_launcher/emr.py
+++ b/emr_launcher/emr.py
@@ -1,0 +1,66 @@
+"""Helpers for interacting with AWS EMR.
+
+These functions provide only minimal behavior and are primarily placeholders
+for the full implementation. They demonstrate how the service might invoke the
+existing configuration tooling and submit a job flow to AWS.
+"""
+from __future__ import annotations
+
+import subprocess
+from typing import Dict, Optional
+
+import boto3
+
+
+def _run(cmd: list[str]) -> None:
+    """Run *cmd* and raise if it fails."""
+    subprocess.run(cmd, check=True)
+
+
+def launch_job(
+    job: str,
+    env: str,
+    experiment: Optional[str],
+    overrides: Dict[str, str],
+    runtime: Dict[str, str],
+    force_run: bool,
+) -> None:
+    """Render configs and submit an EMR job.
+
+    Parameters mirror the JSON payload described in :mod:`emr_launcher.service`.
+    """
+    build_cmd = ["make", "build", f"env={env}"]
+    if experiment:
+        build_cmd.append(f"exp={experiment}")
+    _run(build_cmd)
+
+    # Generate runtime configs
+    gen_cmd = ["make", "generate-runtime-config", f"env={env}"]
+    if experiment:
+        gen_cmd.append(f"exp={experiment}")
+    if runtime.get("run_date"):
+        gen_cmd.append(f"run_date={runtime['run_date']}")
+    if force_run:
+        gen_cmd.append("forceRun=true")
+    _run(gen_cmd)
+
+    # Actual EMR submission is omitted. This demonstrates how the AWS SDK
+    # might be used.
+    emr = boto3.client("emr")
+    emr.run_job_flow(Name=job, Steps=[])  # type: ignore[arg-type]
+
+
+def clone_cluster(cluster_id: str, overrides: Dict[str, str]) -> str:
+    """Clone an existing EMR cluster.
+
+    Returns the identifier of the new cluster.
+    """
+    emr = boto3.client("emr")
+    # Fetch existing configuration. The real implementation would examine
+    # cluster state, steps, and bootstrap actions.
+    cluster = emr.describe_cluster(ClusterId=cluster_id)["Cluster"]
+
+    # Apply overrides and launch a new cluster. This is highly simplified and
+    # intended only as documentation for the expected behavior.
+    response = emr.run_job_flow(Name=cluster["Name"], Steps=[])
+    return response.get("JobFlowId", "")

--- a/emr_launcher/service.py
+++ b/emr_launcher/service.py
@@ -1,0 +1,56 @@
+"""Flask service for launching EMR jobs."""
+from flask import Flask, jsonify, request, render_template
+
+from . import emr
+
+app = Flask(__name__)
+
+
+@app.get("/")
+def index():
+    """Render a placeholder index page."""
+    return render_template("index.html")
+
+
+@app.post("/jobs")
+def create_job():
+    """Launch an EMR job from a template.
+
+    Expected JSON body::
+
+        {
+            "job": "AudienceCalibrationAndMergeJob",
+            "env": "test|experiment|prod",
+            "experiment": "name if env requires it",
+            "overrides": {...},
+            "runtime": {"run_date": "YYYYMMDD"},
+            "forceRun": false
+        }
+    """
+    payload = request.get_json(force=True)
+    emr.launch_job(
+        job=payload["job"],
+        env=payload["env"],
+        experiment=payload.get("experiment"),
+        overrides=payload.get("overrides", {}),
+        runtime=payload.get("runtime", {}),
+        force_run=bool(payload.get("forceRun")),
+    )
+    return jsonify({"status": "submitted"})
+
+
+@app.post("/clone")
+def clone_cluster():
+    """Clone an existing EMR cluster.
+
+    Expects a JSON body::
+
+        {"cluster_id": "j-ABCDEFGHI"}
+    """
+    payload = request.get_json(force=True)
+    new_id = emr.clone_cluster(payload["cluster_id"], payload.get("overrides", {}))
+    return jsonify({"status": "submitted", "cluster_id": new_id})
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    app.run(host="0.0.0.0", port=8080)

--- a/emr_launcher/templates/index.html
+++ b/emr_launcher/templates/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<title>EMR launcher</title>
+<h1>EMR launcher</h1>
+<p>This minimal UI exposes API endpoints for launching or cloning EMR jobs.
+Interact with the service using HTTP clients such as <code>curl</code> or
+<code>Postman</code>.</p>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+boto3


### PR DESCRIPTION
## Summary
- create `emr_launcher` package with a lightweight Flask service
- add helper functions to render configs and submit or clone EMR clusters
- document and expose service via new `make serve` target

## Testing
- `python -m py_compile emr_launcher/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6f364d4cc832693cab10d86dd5796